### PR TITLE
Three new watchers.  Compiles use IEx.Helpers instead of shell.

### DIFF
--- a/lib/rl/watcher.ex
+++ b/lib/rl/watcher.ex
@@ -14,7 +14,7 @@ defmodule Rl.Watcher do
   ]
 
   def init([]) do
-    {:ok, watcher_pid} = FileSystem.start_link(dirs: [System.cwd!()])
+    {:ok, watcher_pid} = FileSystem.start_link(dirs: [File.cwd!()])
     FileSystem.subscribe(watcher_pid)
     state = load_config()
 

--- a/lib/rl/watcher/compile.ex
+++ b/lib/rl/watcher/compile.ex
@@ -1,0 +1,36 @@
+defmodule Rl.Watcher.Compile do
+  @moduledoc false
+  def init(events) do
+    events
+  end
+
+  def handle_events(events, state) do
+    try do
+      IEx.Helpers.recompile()
+      IO.puts("done compiling")
+    catch
+      _, _ -> :error
+    end
+
+    events
+    |> Stream.map(&elem(&1, 0))
+    |> Enum.into(MapSet.new())
+    |> flush()
+
+    {:ok, state}
+  end
+
+  defp flush(prev_events) do
+    receive do
+      {:file_event, _, {file, _}} = event ->
+        if !MapSet.member?(prev_events, file) do
+          :timer.send_after(100, event)
+        end
+
+        flush(prev_events)
+    after
+      10 ->
+        :ok
+    end
+  end
+end

--- a/lib/rl/watcher/compile_format.ex
+++ b/lib/rl/watcher/compile_format.ex
@@ -10,8 +10,11 @@ defmodule Rl.Watcher.CompileFormat do
       IO.puts("done compiling")
     catch
       _, _ -> :error
-    end |> case do
-      :error -> :error
+    end
+    |> case do
+      :error ->
+        :error
+
       _ ->
         Rl.Watcher.Shell.run("mix format")
     end

--- a/lib/rl/watcher/compile_format.ex
+++ b/lib/rl/watcher/compile_format.ex
@@ -1,0 +1,40 @@
+defmodule Rl.Watcher.CompileFormat do
+  @moduledoc false
+  def init(events) do
+    events
+  end
+
+  def handle_events(events, state) do
+    try do
+      IEx.Helpers.recompile()
+      IO.puts("done compiling")
+    catch
+      _, _ -> :error
+    end |> case do
+      :error -> :error
+      _ ->
+        Rl.Watcher.Shell.run("mix format")
+    end
+
+    events
+    |> Stream.map(&elem(&1, 0))
+    |> Enum.into(MapSet.new())
+    |> flush()
+
+    {:ok, state}
+  end
+
+  defp flush(prev_events) do
+    receive do
+      {:file_event, _, {file, _}} = event ->
+        if !MapSet.member?(prev_events, file) do
+          :timer.send_after(100, event)
+        end
+
+        flush(prev_events)
+    after
+      10 ->
+        :ok
+    end
+  end
+end

--- a/lib/rl/watcher/nothing.ex
+++ b/lib/rl/watcher/nothing.ex
@@ -1,0 +1,10 @@
+defmodule Rl.Watcher.Nothing do
+  @moduledoc false
+  def init(events) do
+    events
+  end
+
+  def handle_events(events, state) do
+    {:ok, state}
+  end
+end

--- a/lib/rl/watcher/nothing.ex
+++ b/lib/rl/watcher/nothing.ex
@@ -4,7 +4,7 @@ defmodule Rl.Watcher.Nothing do
     events
   end
 
-  def handle_events(events, state) do
+  def handle_events(_events, state) do
     {:ok, state}
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,10 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm", "1b34655872366414f69dd987cb121c049f76984b6ac69f52fff6d8fd64d29cfd"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
   "erlexec": {:hex, :erlexec, "1.7.1", "6ddbd40fa202084ed0bdaf95a50c334acaa5644ae213b903cd4094a78ae79734", [:rebar3], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "file_system": {:hex, :file_system, "0.2.4", "f0bdda195c0e46e987333e986452ec523aed21d784189144f647c43eaf307064", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},
+  "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.0", "98312c9f0d3730fde4049985a1105da5155bfe5c11e47bdc7406d88e01e4219b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "75ffa34ab1056b7e24844c90bfc62aaf6f3a37a15faa76b07bc5eba27e4a8b4a"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
 }


### PR DESCRIPTION
The reason for the compile change is that if your MIX_BUILD_PATH is not
the default, iex does not pick up compilation changes.  It is also
ever so slightly faster.